### PR TITLE
WIP Shift click multiple selection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+        	<groupId>javax.servlet</groupId>
+		    <artifactId>servlet-api</artifactId>
+		    <version>2.5</version>
+	    </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/com/flowingcode/vaadin/addons/twincolgrid/DemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/twincolgrid/DemoView.java
@@ -56,7 +56,7 @@ public class DemoView extends VerticalLayout {
             "TwinColGrid binding demo, row select without checkbox")
 				.addColumn(Book::getIsbn, "ISBN").addColumn(Book::getTitle, "Title")
 				.withLeftColumnCaption("Available books").withRightColumnCaption("Added books").withoutRemoveAllButton()
-            .withSizeFull().selectRowOnClick();
+                .withSizeFull().withShiftMultiselectAndWithSelectRowOnClick(false);
 
 		final Binder<Library> binder = new Binder<>();
 		binder.bind(bindedTwinColGrid, Library::getBooks, Library::setBooks);

--- a/src/test/java/com/flowingcode/vaadin/addons/twincolgrid/test/SerializationTest.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/twincolgrid/test/SerializationTest.java
@@ -1,0 +1,30 @@
+package com.flowingcode.vaadin.addons.twincolgrid.test;
+
+import com.flowingcode.vaadin.addons.twincolgrid.TwinColGrid;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.Test;
+
+public class SerializationTest {
+
+  private void testSerializationOf(Object obj) throws IOException, ClassNotFoundException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+    try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(new TwinColGrid());
+    }
+
+    try (ObjectInputStream in =
+        new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+      TwinColGrid.class.cast(in.readObject());
+    }
+  }
+
+  @Test
+  public void testSerialization() throws ClassNotFoundException, IOException {
+    testSerializationOf(new TwinColGrid());
+  }
+}


### PR DESCRIPTION
Fixes #14

Added click + shift selection (in unordered and unfiltered grids). Checkbox is optional.

Changed "selectRowOnClick" by "withSelectOnRowClick", and reusing addItemClickListener for both grids on this method.
Added serializationTest