### PR TITLE
fix: make setValue clear the previous value

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGrid.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGrid.java
@@ -658,7 +658,9 @@ public class TwinColGrid<T> extends VerticalLayout
         value.stream()
             .map(Objects::requireNonNull)
             .collect(Collectors.toCollection(LinkedHashSet::new));
-    updateSelection(newValues, new LinkedHashSet<>(getAvailableGrid().getSelectedItems()));
+    final Set<T> oldValues = new LinkedHashSet<>(selection.getItems());
+    oldValues.removeAll(newValues);
+    updateSelection(newValues, oldValues);
   }
 
   /**


### PR DESCRIPTION
The second parameter in the call to `updateSelection` must be the set of items to be removed from the selection (i.e. the items that were selected minus the items that are being selected).

This trace up to the initial commit
https://github.com/FlowingCode/TwinColGridAddon/blame/396f518103548c4b0a76705bfb7bab8b23165c6e/src/main/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGrid.java#L310