### PR TITLE
refactor: replace use of deprecated method

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGridListAdapter.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGridListAdapter.java
@@ -103,7 +103,7 @@ class TwinColGridListAdapter<T> implements HasValue<ValueChangeEvent<List<T>>, L
     }));
 
     // sorting the grid changes its value under List::equals
-    registrations.add(delegate.getRightGrid().addSortListener(ev -> {
+    registrations.add(delegate.getSelectionGrid().addSortListener(ev -> {
       List<T> value = getValue();
       ValueChangeEvent<List<T>> listEvent;
       listEvent = new ValueChangeEventImpl(ev.isFromClient(), value);


### PR DESCRIPTION
Replace use of `getRightGrid` (deprecated) with `getSelectedGrid`

https://github.com/FlowingCode/TwinColGridAddon/blob/82e6eee3e840d480ecf15d3d227088433e09e612/src/main/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGrid.java#L130-L131