### PR TITLE
fix(demo): fix Vaadin 24 runtime error in demo 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <jetty.version>9.4.36.v20210114</jetty.version>
     </properties>
     <organization>
 	   <name>Flowing Code</name>
@@ -162,9 +163,22 @@
             </plugin>
 
             <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-maven-plugin</artifactId>
+                <version>${vaadin.version}</version>
+                <executions>
+                    <execution>
+                            <goals>
+                            <goal>prepare-frontend</goal>
+                            </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>9.4.36.v20210114</version>
+                <version>${jetty.version}</version>
                 <configuration>
                     <scanIntervalSeconds>3</scanIntervalSeconds>
                     <!-- Use test scope because the UI/demo classes are in 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<version>2.9.3-SNAPSHOT</version>
 	<name>TwinColGrid add-on</name>
     <properties>
-        <vaadin.version>14.8.3</vaadin.version>
+        <vaadin.version>14.9.7</vaadin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 		<dependency>
 			<groupId>com.flowingcode.vaadin.addons.demo</groupId>
 			<artifactId>commons-demo</artifactId>
-			<version>3.5.0</version>
+			<version>3.6.0</version>
 			<scope>test</scope>
 		</dependency>
     </dependencies>

--- a/src/test/java/com/flowingcode/vaadin/addons/twincolgrid/CompatibilityExtension.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/twincolgrid/CompatibilityExtension.java
@@ -1,0 +1,28 @@
+package com.flowingcode.vaadin.addons.twincolgrid;
+
+import com.vaadin.flow.component.select.Select;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/** Binary compatibility utils for Vaadin 14-24 */
+public class CompatibilityExtension {
+
+  private static final Method setItems = lookupSetItems();
+
+  private static Method lookupSetItems() {
+    try {
+      return Select.class.getMethod("setItems", Object[].class);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static <T> void setItems(Select<T> select, T[] items) {    
+    try {
+      setItems.invoke(select, (Object) items);
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/twincolgrid/OrientationDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/twincolgrid/OrientationDemo.java
@@ -31,11 +31,13 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import lombok.experimental.ExtensionMethod;
 
 @SuppressWarnings("serial")
 @PageTitle("Orientation")
 @DemoSource
 @Route(value = "twincolgrid/orientation", layout = TwincolDemoView.class)
+@ExtensionMethod(CompatibilityExtension.class) // hide-source
 public class OrientationDemo extends VerticalLayout {
 
   private final Set<Book> selectedBooks = new HashSet<>();


### PR DESCRIPTION
Use Lombok `ExtensionMethod` in order to hide complexity from the code snippet published in the demo site.