### PR TITLE
fix: define a min-height to avoid confusion

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/styles/twincol-grid.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/twincol-grid.css
@@ -18,6 +18,9 @@
  * #L%
  */
 
+.twincol-grid {
+  min-height: calc(var(--lumo-space-m) * 13);
+}
 .twincol-grid .twincol-grid-label {
   color: var(--lumo-secondary-text-color);
   font-weight: 500;


### PR DESCRIPTION
Define a min-height based on lumo variable to avoid confusion when the parent height is relative (items are not rendered)
Closes #125 