### PR TITLE
build: restore original name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.flowingcode.vaadin.addons</groupId>
 	<artifactId>twincolgrid</artifactId>
 	<version>3.0.0-SNAPSHOT</version>
-	<name>TwinColGrid</name>
+	<name>TwinColGrid add-on</name>
 	<description>Dual list component based on Vaadin Grids</description>
 	<url>https://www.flowingcode.com/en/open-source/</url>
 	


### PR DESCRIPTION
The `<name>` had been inadvertently changed in #148 