### PR TITLE
fix: fix double-click in read-only mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<url>https://www.flowingcode.com/en/open-source/</url>
 	
     <properties>
-        <vaadin.version>14.8.20</vaadin.version>
+        <vaadin.version>14.11.13</vaadin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGrid.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGrid.java
@@ -150,7 +150,7 @@ public class TwinColGrid<T> extends VerticalLayout
   private boolean explicitHeaderRow = true;
 
   private String layoutId;
-  
+
   private static <T> ListDataProvider<T> emptyDataProvider() {
     return DataProvider.ofCollection(new LinkedHashSet<>());
   }
@@ -339,7 +339,7 @@ public class TwinColGrid<T> extends VerticalLayout
       return this.layoutId = "twincol-" + UUID.randomUUID();
     });
   }
-  
+
   private HorizontalLayout createHorizontalContainer(boolean reverse) {
     buttonContainer = getVerticalButtonContainer();
     HorizontalLayout hl;
@@ -928,12 +928,14 @@ public class TwinColGrid<T> extends VerticalLayout
             side.moveItemsByDoubleClick =
                 side.grid.addItemDoubleClickListener(
                     ev -> {
-                      Set<T> item = Collections.singleton(ev.getItem());
-                      if (side == available) {
-                        updateSelection(item, Collections.emptySet(), true);
-                      }
-                      if (side == selection) {
-                        updateSelection(Collections.emptySet(), item, true);
+                      if (!isReadOnly()) {
+                        Set<T> item = Collections.singleton(ev.getItem());
+                        if (side == available) {
+                          updateSelection(item, Collections.emptySet(), true);
+                        }
+                        if (side == selection) {
+                          updateSelection(Collections.emptySet(), item, true);
+                        }
                       }
                     });
           }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded Vaadin framework to version 14.11.13.
	- Introduced profiles for Vaadin versions 23 and 24, supporting different Java versions.
	- Enhanced `TwinColGrid` with improved layout management and item interaction capabilities.

- **Bug Fixes**
	- Added checks to prevent item movement in read-only grid state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->