### PR TITLE
feat: add CSS class for Read-Only mode

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGrid.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGrid.java
@@ -684,6 +684,7 @@ public class TwinColGrid<T> extends VerticalLayout
     removeButton.setEnabled(!readOnly);
     addAllButton.setEnabled(!readOnly);
     removeAllButton.setEnabled(!readOnly);
+    setClassName("readonly", readOnly);
   }
 
   @Override


### PR DESCRIPTION
Close #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visual representation of the TwinColGrid component by applying a "readonly" CSS class when in read-only mode. 

- **Bug Fixes**
	- Improved management of selection modes based on the read-only status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->