### PR TITLE
docs(readme): remove vaadin directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,6 @@ Add the following dependencies in your pom.xml file:
 </dependency>
 ```
 
-```xml
-<repository>
-   <id>vaadin-addons</id>
-   <url>https://maven.vaadin.com/vaadin-addons</url>
-</repository>
-```
-
 For SNAPSHOT versions see [here](https://maven.flowingcode.com/snapshots/).
 
 ## Building and running demo


### PR DESCRIPTION
Starting with 2.9.3, this add-on is released through Maven Central (see https://mvnrepository.com/artifact/com.flowingcode.vaadin.addons/twincolgrid)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed an outdated repository reference from the documentation.
  - Adjusted formatting for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->