### PR TITLE
fix: return modifiable collections from getValue()

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGrid.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGrid.java
@@ -618,8 +618,7 @@ public class TwinColGrid<T> extends VerticalLayout
    */
   @Override
   public Set<T> getValue() {
-    return Collections.unmodifiableSet(
-        collectValue(Collectors.<T, Set<T>>toCollection(LinkedHashSet::new)));
+    return collectValue(Collectors.<T, Set<T>>toCollection(LinkedHashSet::new));
   }
 
   /**

--- a/src/main/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGridListAdapter.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGridListAdapter.java
@@ -85,7 +85,7 @@ class TwinColGridListAdapter<T> implements HasValue<ValueChangeEvent<List<T>>, L
 
   @Override
   public List<T> getValue() {
-    return Collections.unmodifiableList(delegate.collectValue(Collectors.toList()));
+    return delegate.collectValue(Collectors.toList());
   }
 
   @Override

--- a/src/test/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGridListAdapterTest.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGridListAdapterTest.java
@@ -1,0 +1,64 @@
+package com.flowingcode.vaadin.addons.twincolgrid;
+
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public class TwinColGridListAdapterTest {
+
+    @Test
+    public void testGetValueReturnsModifiableListAndDoesNotAffectInternalState() {
+        // 1. Instantiate a TwinColGrid<String>
+        TwinColGrid<String> twinColGrid = new TwinColGrid<>();
+
+        // 2. Instantiate TwinColGridListAdapter<String> with the created TwinColGrid
+        TwinColGridListAdapter<String> adapter = new TwinColGridListAdapter<>(twinColGrid);
+
+        // 3. Add a few initial items (e.g., "Vixen", "Comet") to the TwinColGrid's selection.
+        Set<String> initialSelection = new LinkedHashSet<>(Arrays.asList("Vixen", "Comet"));
+        twinColGrid.setValue(initialSelection);
+
+        // 4. Call getValue() on the TwinColGridListAdapter instance.
+        List<String> listFromAdapter = adapter.getValue();
+
+        // 5. Assert that the returned List<String> is not null and contains the initial items.
+        Assert.assertNotNull("The list returned by getValue() should not be null.", listFromAdapter);
+        Assert.assertEquals("The list should contain 2 items.", 2, listFromAdapter.size());
+        Assert.assertTrue("The list should contain 'Vixen'.", listFromAdapter.contains("Vixen"));
+        Assert.assertTrue("The list should contain 'Comet'.", listFromAdapter.contains("Comet"));
+
+        // 6. Attempt to add a new item (e.g., "Cupid") to the list obtained in step 4.
+        //    Verify that this operation is successful (no exception thrown) and the list now contains "Cupid".
+        boolean added = false;
+        try {
+            added = listFromAdapter.add("Cupid");
+        } catch (UnsupportedOperationException e) {
+            Assert.fail("The list should be modifiable, but add operation threw UnsupportedOperationException.");
+        }
+        Assert.assertTrue("The add operation should return true, indicating the list was modified.", added);
+        Assert.assertEquals("The list from adapter should now contain 3 items.", 3, listFromAdapter.size());
+        Assert.assertTrue("The list from adapter should now contain 'Cupid'.", listFromAdapter.contains("Cupid"));
+
+        // 7. Call getValue() on the TwinColGridListAdapter again
+        List<String> secondListFromAdapter = adapter.getValue();
+
+        // 8. Assert that this second list *only* contains the original items ("Vixen", "Comet")
+        //    and *does not* contain "Cupid".
+        Assert.assertNotNull("The second list returned by getValue() should not be null.", secondListFromAdapter);
+        Assert.assertEquals("The second list should still contain 2 items (original state).", 2, secondListFromAdapter.size());
+        Assert.assertTrue("The second list should contain 'Vixen'.", secondListFromAdapter.contains("Vixen"));
+        Assert.assertTrue("The second list should contain 'Comet'.", secondListFromAdapter.contains("Comet"));
+        Assert.assertFalse("The second list should NOT contain 'Cupid'.", secondListFromAdapter.contains("Cupid"));
+
+        // Also, verify the underlying TwinColGrid's value directly
+        Set<String> twinColGridValue = twinColGrid.getValue();
+        Assert.assertNotNull("The TwinColGrid's value should not be null.", twinColGridValue);
+        Assert.assertEquals("The TwinColGrid's value should contain 2 items.", 2, twinColGridValue.size());
+        Assert.assertTrue("The TwinColGrid's value should contain 'Vixen'.", twinColGridValue.contains("Vixen"));
+        Assert.assertTrue("The TwinColGrid's value should contain 'Comet'.", twinColGridValue.contains("Comet"));
+        Assert.assertFalse("The TwinColGrid's value should NOT contain 'Cupid'.", twinColGridValue.contains("Cupid"));
+    }
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGridTest.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/twincolgrid/TwinColGridTest.java
@@ -1,0 +1,56 @@
+package com.flowingcode.vaadin.addons.twincolgrid;
+
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.LinkedHashSet;
+
+public class TwinColGridTest {
+
+    @Test
+    public void testGetValueReturnsModifiableSet() {
+        // 1. Create an instance of TwinColGrid<String>
+        TwinColGrid<String> twinColGrid = new TwinColGrid<>();
+
+        // 2. Add a couple of items to the selection side of the grid.
+        //    To do this, we first set items to the available side,
+        //    then simulate moving them to the selection side.
+        //    Alternatively, setValue directly manipulates the selection.
+        Set<String> initialSelection = new LinkedHashSet<>(Arrays.asList("Dasher", "Dancer"));
+        twinColGrid.setValue(initialSelection);
+
+        // 3. Call the getValue() method to get the set of selected items.
+        Set<String> selectedItems = twinColGrid.getValue();
+
+        // 4. Assert that the returned set is not null and contains the expected items.
+        Assert.assertNotNull("The set returned by getValue() should not be null.", selectedItems);
+        Assert.assertEquals("The set should contain 2 items.", 2, selectedItems.size());
+        Assert.assertTrue("The set should contain 'Dasher'.", selectedItems.contains("Dasher"));
+        Assert.assertTrue("The set should contain 'Dancer'.", selectedItems.contains("Dancer"));
+
+        // 5. Attempt to add a new item (e.g., "Prancer") to the set returned by getValue().
+        boolean added = false;
+        try {
+            added = selectedItems.add("Prancer");
+        } catch (UnsupportedOperationException e) {
+            Assert.fail("The set should be modifiable, but add operation threw UnsupportedOperationException.");
+        }
+
+        // 6. Assert that the add operation was successful and the set now contains the newly added item.
+        Assert.assertTrue("The add operation should return true, indicating the set was modified.", added);
+        Assert.assertEquals("The set should now contain 3 items.", 3, selectedItems.size());
+        Assert.assertTrue("The set should contain 'Prancer'.", selectedItems.contains("Prancer"));
+
+        // 7. Call getValue() on the TwinColGrid instance again to get a fresh set.
+        Set<String> internalSelectionAfterModification = twinColGrid.getValue();
+
+        // 8. Assert that this new set contains only the original items and does not contain "Prancer".
+        Assert.assertNotNull("The internal set fetched after modification should not be null.", internalSelectionAfterModification);
+        Assert.assertEquals("The internal set should still contain 2 original items.", 2, internalSelectionAfterModification.size());
+        Assert.assertTrue("The internal set should still contain 'Dasher'.", internalSelectionAfterModification.contains("Dasher"));
+        Assert.assertTrue("The internal set should still contain 'Dancer'.", internalSelectionAfterModification.contains("Dancer"));
+        Assert.assertFalse("The internal set should NOT contain 'Prancer'.", internalSelectionAfterModification.contains("Prancer"));
+    }
+}


### PR DESCRIPTION
Close #193
- `TwinColGrid.getValue()` and `TwinColGridListAdapter.getValue(`) now return modifiable collections.
- Modifications to the collections returned by `getValue()` do not affect the internal state of the components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated selection retrieval methods to return modifiable collections, allowing users to modify the returned lists and sets without affecting the component's internal state.
- **Tests**
	- Added new tests to ensure that modifying the returned collections does not impact the internal data of the components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->